### PR TITLE
Include full response

### DIFF
--- a/lib/do-wrapper.js
+++ b/lib/do-wrapper.js
@@ -358,6 +358,18 @@ DigitalOcean.prototype.sizesGetAll = function(callback) {
 };
 
 /*
+*   Type: Account
+*   Action: Get User Information
+*   More Information: https://developers.digitalocean.com/documentation/v2/#account
+*/
+DigitalOcean.prototype.account = function(callback) {
+    var url = 'account';
+    this._get(url, function(err, body) {
+        callback(err, body);
+    });
+};
+
+/*
 *   Type: Keys
 *   Action: List All Keys
 *   More Information: https://developers.digitalocean.com/#list-all-keys

--- a/lib/do-wrapper.js
+++ b/lib/do-wrapper.js
@@ -58,7 +58,7 @@ DigitalOcean.prototype._get = function(action, callback) {
             err = new Error(body.description || body);
         }
 
-        callback(err, body || {});
+        callback(err, body || {}, response);
     });
 };
 
@@ -79,7 +79,7 @@ DigitalOcean.prototype._post = function(action, body, callback) {
             if (!err && !!body.status && body.status !== 'OK') {
                 err = new Error(body.description || body);
             }
-            callback(err, body || {});
+            callback(err, body || {}, response);
         });
 };
 
@@ -106,8 +106,8 @@ DigitalOcean.prototype._delete = function(action, callback) {
 *   More Information: https://developers.digitalocean.com/#list-all-droplets
 */
 DigitalOcean.prototype.dropletsGetAll = function(callback) {
-    this._get('droplets/', function(err, body) {
-        callback(err, body);
+    this._get('droplets/', function(err, body, response) {
+        callback(err, body, response);
     });
 };
 
@@ -118,8 +118,8 @@ DigitalOcean.prototype.dropletsGetAll = function(callback) {
 */
 DigitalOcean.prototype.dropletsGetKernelsForDroplet = function(dropletID, callback) {
     var url = 'droplets/' + dropletID + '/kernels';
-    this._get(url, function(err, body) {
-        callback(err, body);
+    this._get(url, function(err, body, response) {
+        callback(err, body, response);
     });
 };
 
@@ -130,8 +130,8 @@ DigitalOcean.prototype.dropletsGetKernelsForDroplet = function(dropletID, callba
 */
 DigitalOcean.prototype.dropletsGetSnapshotsForDroplet = function(dropletID, callback) {
     var url = 'droplets/' + dropletID + '/snapshots';
-    this._get(url, function(err, body) {
-        callback(err, body);
+    this._get(url, function(err, body, response) {
+        callback(err, body, response);
     });
 };
 
@@ -142,8 +142,8 @@ DigitalOcean.prototype.dropletsGetSnapshotsForDroplet = function(dropletID, call
 */
 DigitalOcean.prototype.dropletsGetBackupsForDroplet = function(dropletID, callback) {
     var url = 'droplets/' + dropletID + '/backups';
-    this._get(url, function(err, body) {
-        callback(err, body);
+    this._get(url, function(err, body, response) {
+        callback(err, body, response);
     });
 };
 
@@ -154,8 +154,8 @@ DigitalOcean.prototype.dropletsGetBackupsForDroplet = function(dropletID, callba
 */
 DigitalOcean.prototype.dropletsGetActionsForDroplet = function(dropletID, callback) {
     var url = "droplets/" + dropletID + '/actions';
-    this._get(url, function(err, body) {
-        callback(err, body);
+    this._get(url, function(err, body, response) {
+        callback(err, body, response);
     });
 };
 
@@ -175,8 +175,8 @@ DigitalOcean.prototype.dropletsCreateNewDroplet = function(name, region, size, i
 
     options = extend(options, extras);
 
-    this._post(url, options, function(err, body) {
-        callback(err, body);
+    this._post(url, options, function(err, body, response) {
+        callback(err, body, response);
     });
 };
 
@@ -187,8 +187,8 @@ DigitalOcean.prototype.dropletsCreateNewDroplet = function(name, region, size, i
 */
 DigitalOcean.prototype.dropletsGetDropletById = function(dropletID, callback) {
     var url = 'droplets/' + dropletID;
-    this._get(url, function(err, body) {
-        callback(err, body);
+    this._get(url, function(err, body, response) {
+        callback(err, body, response);
     });
 };
 
@@ -199,8 +199,8 @@ DigitalOcean.prototype.dropletsGetDropletById = function(dropletID, callback) {
 */
 DigitalOcean.prototype.dropletsDeleteDroplet = function(dropletID, callback) {
     var url = 'droplets/' + dropletID;
-    this._delete(url, function(err, body) {
-        callback(err, body);
+    this._delete(url, function(err, response) {
+        callback(err, response);
     });
 };
 
@@ -215,8 +215,8 @@ DigitalOcean.prototype.dropletActionRequest = function(dropletID, action, option
 
     action = extend(action, options);
 
-    this._post(url, action, function(err, body) {
-        callback(err, body.action);
+    this._post(url, action, function(err, body, response) {
+        callback(err, body.action, response);
     });
 };
 
@@ -227,8 +227,8 @@ DigitalOcean.prototype.dropletActionRequest = function(dropletID, action, option
 */
 DigitalOcean.prototype.dropletActionGetStatus = function(dropletID, actionID, callback) {
     var url = 'droplets/' + dropletID + '/actions/' + actionID;
-    this._get(url, function(err, body) {
-        callback(err, body);
+    this._get(url, function(err, body, response) {
+        callback(err, body, response);
     });
 };
 
@@ -239,8 +239,8 @@ DigitalOcean.prototype.dropletActionGetStatus = function(dropletID, actionID, ca
 */
 DigitalOcean.prototype.domainGetAll = function(callback) {
     var url = 'domains/';
-    this._get(url, function(err, body) {
-        callback(err, body);
+    this._get(url, function(err, body, response) {
+        callback(err, body, response);
     });
 };
 
@@ -252,8 +252,8 @@ DigitalOcean.prototype.domainGetAll = function(callback) {
 DigitalOcean.prototype.domainAddNew = function(domain, ip, callback) {
     var url = 'domains/',
         options = {"name": domain, "ip_address": ip};
-    this._post(url, options, function(err, body) {
-        callback(err, body);
+    this._post(url, options, function(err, body, response) {
+        callback(err, body, response);
     });
 };
 
@@ -264,10 +264,10 @@ DigitalOcean.prototype.domainAddNew = function(domain, ip, callback) {
 */
 DigitalOcean.prototype.domainGetByName = function(domain, callback) {
     var url = 'domains/' + domain;
-    this._get(url, function(err, body) {
-        callback(err, body);
+    this._get(url, function(err, body, response) {
+        callback(err, body, response);
     });
-}
+};
 
 /*
  *   Type: Domain
@@ -276,8 +276,8 @@ DigitalOcean.prototype.domainGetByName = function(domain, callback) {
  */
 DigitalOcean.prototype.domainDeleteDomain = function(domain, callback) {
     var url = 'domains/' + domain;
-    this._delete(url, function(err, body) {
-        callback(err, body);
+    this._delete(url, function(err, response) {
+        callback(err, response);
     });
 };
 
@@ -288,8 +288,8 @@ DigitalOcean.prototype.domainDeleteDomain = function(domain, callback) {
 */
 DigitalOcean.prototype.domainRecordsGetAll = function(domain, callback) {
     var url = 'domains/' + domain + '/records';
-    this._get(url, function(err, body) {
-        callback(err, body);
+    this._get(url, function(err, body, response) {
+        callback(err, body, response);
     });
 };
 
@@ -304,8 +304,8 @@ DigitalOcean.prototype.domainRecordsAddnew = function(domain, type, options, cal
 
     body = extend(body, options);
 
-    this._post(url, body, function(err, body) {
-        callback(err, body);
+    this._post(url, body, function(err, body, response) {
+        callback(err, body, response);
     });
 };
 
@@ -316,8 +316,8 @@ DigitalOcean.prototype.domainRecordsAddnew = function(domain, type, options, cal
 */
 DigitalOcean.prototype.domainRecordsGetRecord = function(domain, recordID, callback) {
     var url = 'domains/' + domain + '/records/' + recordID;
-    this._get(url, function(err, body) {
-        callback(err, body);
+    this._get(url, function(err, body, response) {
+        callback(err, body, response);
     });
 };
 
@@ -328,8 +328,8 @@ DigitalOcean.prototype.domainRecordsGetRecord = function(domain, recordID, callb
 */
 DigitalOcean.prototype.domainRecordsDeleteRecord = function(domain, recordID, callback) {
     var url = 'domains/' + domain + '/records/' + recordID;
-    this._delete(url, function(err, body) {
-        callback(err, body);
+    this._delete(url, function(err, response) {
+        callback(err, response);
     });
 };
 
@@ -340,8 +340,8 @@ DigitalOcean.prototype.domainRecordsDeleteRecord = function(domain, recordID, ca
 */
 DigitalOcean.prototype.regionsGetAll = function(callback) {
     var url = 'regions/';
-    this._get(url, function(err, body) {
-        callback(err, body);
+    this._get(url, function(err, body, response) {
+        callback(err, body, response);
     });
 };
 
@@ -352,8 +352,8 @@ DigitalOcean.prototype.regionsGetAll = function(callback) {
 */
 DigitalOcean.prototype.sizesGetAll = function(callback) {
     var url = 'sizes/';
-    this._get(url, function(err, body) {
-        callback(err, body);
+    this._get(url, function(err, body, response) {
+        callback(err, body, response);
     });
 };
 
@@ -364,8 +364,8 @@ DigitalOcean.prototype.sizesGetAll = function(callback) {
 */
 DigitalOcean.prototype.account = function(callback) {
     var url = 'account';
-    this._get(url, function(err, body) {
-        callback(err, body);
+    this._get(url, function(err, body, response) {
+        callback(err, body, response);
     });
 };
 
@@ -376,8 +376,8 @@ DigitalOcean.prototype.account = function(callback) {
 */
 DigitalOcean.prototype.keysGetAll = function(callback) {
     var url = 'account/keys/';
-    this._get(url, function(err, body) {
-        callback(err, body);
+    this._get(url, function(err, body, response) {
+        callback(err, body, response);
     });
 };
 
@@ -389,8 +389,8 @@ DigitalOcean.prototype.keysGetAll = function(callback) {
 DigitalOcean.prototype.keysAddNew = function(name, key, callback) {
     var url = 'account/keys/',
         body = {"name": name, "public_key": key};
-    this._post(url, body, function(err, body) {
-        callback(err, body);
+    this._post(url, body, function(err, body, response) {
+        callback(err, body, response);
     });
 };
 
@@ -401,8 +401,8 @@ DigitalOcean.prototype.keysAddNew = function(name, key, callback) {
 */
 DigitalOcean.prototype.keysGetKey = function(keyID, callback) {
     var url = 'account/keys/' + keyID;
-    this._get(url, function(err, body) {
-        callback(err, body);
+    this._get(url, function(err, body, response) {
+        callback(err, body, response);
     });
 };
 
@@ -414,8 +414,8 @@ DigitalOcean.prototype.keysGetKey = function(keyID, callback) {
 DigitalOcean.prototype.keysUpdateKey = function(keyID, name, callback) {
     var url = 'account/keys/' + keyID,
         body = {"name": name};
-    this._post(url, body, function(err, body) {
-        callback(err, body);
+    this._post(url, body, function(err, body, response) {
+        callback(err, body, response);
     });
 };
 
@@ -426,8 +426,8 @@ DigitalOcean.prototype.keysUpdateKey = function(keyID, name, callback) {
 */
 DigitalOcean.prototype.keysDestroyKey = function(keyID, callback) {
     var url = 'account/keys/' + keyID;
-    this._delete(url, function(err, body) {
-        callback(err, body);
+    this._delete(url, function(err, response) {
+        callback(err, response);
     });
 };
 
@@ -438,8 +438,8 @@ DigitalOcean.prototype.keysDestroyKey = function(keyID, callback) {
 */
 DigitalOcean.prototype.imagesGetAll = function(callback) {
     var url = 'images/';
-    this._get(url, function(err, body) {
-        callback(err, body);
+    this._get(url, function(err, body, response) {
+        callback(err, body, response);
     });
 };
 
@@ -450,8 +450,8 @@ DigitalOcean.prototype.imagesGetAll = function(callback) {
 */
 DigitalOcean.prototype.imagesGetImage = function(imageID, callback) {
     var url = 'images/' + imageID;
-    this._get(url, function(err, body) {
-        callback(err, body);
+    this._get(url, function(err, body, response) {
+        callback(err, body, response);
     });
 };
 
@@ -462,8 +462,8 @@ DigitalOcean.prototype.imagesGetImage = function(imageID, callback) {
 */
 DigitalOcean.prototype.imagesGetBySlug = function(imageSlug, callback) {
     var url = 'images/' + imageSlug;
-    this._get(url, function(err, body) {
-        callback(err, body);
+    this._get(url, function(err, body, response) {
+        callback(err, body, response);
     });
 };
 
@@ -474,8 +474,8 @@ DigitalOcean.prototype.imagesGetBySlug = function(imageSlug, callback) {
 */
 DigitalOcean.prototype.imagesDeleteImage = function(imageID, callback) {
     var url = 'images/' + imageID;
-    this._delete(url, function(err, body) {
-        callback(err, body);
+    this._delete(url, function(err, response) {
+        callback(err, response);
     });
 };
 
@@ -487,8 +487,8 @@ DigitalOcean.prototype.imagesDeleteImage = function(imageID, callback) {
 DigitalOcean.prototype.imagesTransferImage = function(imageID, region, callback) {
     var url = 'images/' + imageID + '/actions',
         body = {"type": "transfer", "region": region};
-    this._post(url, body, function(err, body) {
-        callback(err, body);
+    this._post(url, body, function(err, body, response) {
+        callback(err, body, response);
     });
 };
 
@@ -499,7 +499,7 @@ DigitalOcean.prototype.imagesTransferImage = function(imageID, region, callback)
 */
 DigitalOcean.prototype.imagesGetActionStatus = function(imageID, actionID, callback) {
     var url = 'images/' + imageID + '/action/' + actionID;
-    this._get(url, function(err, body) {
-        callback(err, body);
+    this._get(url, function(err, body, response) {
+        callback(err, body, response);
     });
 };


### PR DESCRIPTION
This includes the full response as the last element of each callback.

This is useful for getting the headers from the response, which contain additional metadata including the user's current ratelimit status.

NOTE: This PR also includes the new `account` endpoint described at: https://developers.digitalocean.com/documentation/v2/#account
